### PR TITLE
 Implementar Swagger no backend

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -36,13 +36,31 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger2</artifactId>
+			<version>2.9.2</version>
+		</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger-ui</artifactId>
+			<version>2.9.2</version>
+		</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-bean-validators</artifactId>
+			<version>2.9.2</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>
 			<optional>true</optional>
-		</dependency>		
+		</dependency>
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>

--- a/backend/src/main/java/br/com/house/digital/projetointegrador/configuration/SwaggerConfig.java
+++ b/backend/src/main/java/br/com/house/digital/projetointegrador/configuration/SwaggerConfig.java
@@ -1,0 +1,26 @@
+package br.com.house.digital.projetointegrador.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+@Import({springfox.bean.validators.configuration.BeanValidatorPluginsConfiguration.class})
+public class SwaggerConfig {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build();
+    }
+
+}

--- a/backend/src/main/java/br/com/house/digital/projetointegrador/security/WebSecurityConfig.java
+++ b/backend/src/main/java/br/com/house/digital/projetointegrador/security/WebSecurityConfig.java
@@ -1,6 +1,7 @@
 package br.com.house.digital.projetointegrador.security;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -20,14 +21,17 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
-    @Autowired
-    private JWTAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JWTAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
-    @Autowired
-    private UserDetailsService jwtUserDetailsService;
+    private final UserDetailsService jwtUserDetailsService;
 
-    @Autowired
-    private JWTRequestFilter jwtRequestFilter;
+    private final JWTRequestFilter jwtRequestFilter;
+
+    public WebSecurityConfig(JWTAuthenticationEntryPoint jwtAuthenticationEntryPoint, @Qualifier("userDetailsServiceImpl") UserDetailsService jwtUserDetailsService, JWTRequestFilter jwtRequestFilter) {
+        this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
+        this.jwtUserDetailsService = jwtUserDetailsService;
+        this.jwtRequestFilter = jwtRequestFilter;
+    }
 
     @Autowired
     public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
@@ -50,11 +54,17 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity httpSecurity) throws Exception {
-        // We don't need CSRF for this example
         httpSecurity.csrf().disable()
                 // don't authenticate this particular request
                 .authorizeRequests()
-                    .antMatchers("/", "/login", "/register", "/static/**", "/v1/api/authenticate", "/v1/api/register")
+                    .antMatchers(
+                        "/v1/api/authenticate", // API de autenticação
+                        "/v1/api/register", // API de registro
+                        "/webjars/**", // Swagger
+                        "/swagger-ui.html", // Swagger
+                        "/swagger-resources/**", // Swagger
+                        "/v2/api-docs" // Swagger
+                    )
                     .permitAll()
                 // all other requests need to be authenticated
                 .anyRequest()


### PR DESCRIPTION
Closes #34 

- Adicionado a dependência do Maven para o Swagger.
- Criada classe de configuração para o Swagger.
- Adicionado caminhos do Swagger no Spring Security para não precisarem de autenticação.

Documentação do Swagger disponível nos seguintes links:

http://127.0.0.1:8080/v2/api-docs - em formato JSON;
http://127.0.0.1:8080/swagger-ui.html - em formato HTML, onde também é possível testar os endpoints.